### PR TITLE
chore(deps): update dependencies which were causing warnings on install

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  # Enable version updates for npm
+  - package-ecosystem: "npm"
+    # Look for `package.json` and `lock` files in the `root` directory
+    directory: "/"
+    # Check for updates once a week
+    schedule:
+      interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,10 @@ updates:
     directory: "/"
     # Check for updates once a week
     schedule:
-      interval: "weekly"
+      interval: "monthly"
+    allow:
+      # Allow direct updates only (for packages named in package.json)
+      - dependency-type: "direct"
+    commit-message:
+      prefix: "chore(deps): "
+      prefix-development: "chore(deps-dev): "

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -27,7 +27,7 @@ module.exports = function (grunt) {
         }
     });
     // Load the plugin(s):
-    grunt.loadNpmTasks("gpii-grunt-lint-all");
+    grunt.loadNpmTasks("fluid-grunt-lint-all");
     grunt.loadNpmTasks("grunt-contrib-copy");
     // Custom tasks:
     grunt.registerTask("default", ["lint"]);

--- a/package.json
+++ b/package.json
@@ -21,21 +21,19 @@
     "homepage": "https://github.com/fluid-project/fluidic-11ty#readme",
     "dependencies": {
         "@11ty/eleventy": "0.11.0",
-        "@11ty/eleventy-plugin-rss": "1.0.7",
+        "@11ty/eleventy-plugin-rss": "1.0.9",
         "@11ty/eleventy-plugin-syntaxhighlight": "3.0.1"
     },
     "devDependencies": {
-        "@tbranyen/jsdom": "13.0.0",
-        "debug": "4.1.1",
-        "gpii-grunt-lint-all": "1.0.7",
-        "grunt": "1.1.0",
+        "debug": "4.2.0",
+        "fluid-grunt-lint-all": "1.0.8",
+        "grunt": "1.3.0",
         "grunt-contrib-clean": "2.0.0",
         "grunt-contrib-copy": "1.0.0",
         "html-minifier": "4.0.0",
-        "image-size": "0.8.3",
+        "image-size": "0.9.1",
         "infusion": "3.0.0-dev.20200326T173810Z.24ddb2718",
-        "sanitize-html": "1.24.0",
-        "sanitize.css": "11.0.1",
+        "jsdom": "16.4.0",
         "slugify": "1.4.0"
     }
 }

--- a/src/transforms/parse-transform.js
+++ b/src/transforms/parse-transform.js
@@ -1,5 +1,5 @@
 "use strict";
-const jsdom = require("@tbranyen/jsdom");
+const jsdom = require("jsdom");
 const {JSDOM} = jsdom;
 const minify = require("../utils/minify.js");
 const slugify = require("slugify");


### PR DESCRIPTION
This PR updates the deprecated `gpii-grunt-lint-all` package to the newly-renamed `fluid-grunt-lint-all` package, and replaces the older namespaced version of `jsdom` with the current version. It also updates a few other packages to their most recent versions.