### PR TITLE
feat: improve slug filter

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -18,6 +18,7 @@ const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 // Import filters
 const dateFilter = require('./src/filters/date-filter.js');
 const markdownFilter = require('./src/filters/markdown-filter.js');
+const slugFilter = require('./src/filters/slug-filter.js');
 const w3DateFilter = require('./src/filters/w3-date-filter.js');
 
 // Import transforms
@@ -31,6 +32,7 @@ module.exports = function(config) {
   // Filters
   config.addFilter('dateFilter', dateFilter);
   config.addFilter('markdownFilter', markdownFilter);
+  config.addFilter('slug', slugFilter);
   config.addFilter('w3DateFilter', w3DateFilter);
 
 

--- a/src/filters/slug-filter.js
+++ b/src/filters/slug-filter.js
@@ -1,0 +1,22 @@
+/*
+Copyright the Fluidic Eleventy copyright holders.
+
+See the AUTHORS.md file at the top-level directory of this distribution and at
+https://github.com/fluid-project/fluidic-11ty/raw/master/AUTHORS.md.
+
+Licensed under the New BSD license. You may not use this file except in compliance with this License.
+
+You may obtain a copy of the New BSD License at
+https://github.com/fluid-project/fluidic-11ty/raw/master/LICENSE.md.
+*/
+
+"use strict";
+const slugify = require("slugify");
+
+module.exports = function (string) {
+    return slugify(string, {
+        replacement: "-",
+        lower: true,
+        strict: true
+    });
+};


### PR DESCRIPTION
This PR improves Eleventy's default `slug` filter (used to generate URL-friendly versions of page/post titles) to run [slugify](https://www.npmjs.com/package/slugify) in strict mode. The difference is that strict mode removes all special characters. 

## Before

```nunjucks
{% set someValue = "Here’s my title!" %}
{{ someValue | slug }}
```

Returns: `here‘s-my-title!`

## After

```nunjucks
{% set someValue = "Here’s my title!" %}
{{ someValue | slug }}
```

Returns: `heres-my-title`