### PR TITLE
feat: load filters from plugin

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -12,6 +12,7 @@ https://github.com/fluid-project/fluidic-11ty/raw/master/LICENSE.md.
 
 const fs = require("fs");
 
+const fluidPlugin = require("@fluid-project/eleventy-plugin-fluid");
 const rssPlugin = require('@11ty/eleventy-plugin-rss');
 const syntaxHighlight = require('@11ty/eleventy-plugin-syntaxhighlight');
 
@@ -32,7 +33,6 @@ module.exports = function(config) {
   config.addFilter('dateFilter', dateFilter);
   config.addFilter('markdownFilter', markdownFilter);
   config.addFilter('w3DateFilter', w3DateFilter);
-
 
   // Transforms
   config.addTransform('htmlmin', htmlMinTransform);
@@ -80,6 +80,7 @@ module.exports = function(config) {
   });
 
   // Plugins
+  config.addPlugin(fluidPlugin);
   config.addPlugin(rssPlugin);
   config.addPlugin(syntaxHighlight);
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@11ty/eleventy": "0.11.0",
         "@11ty/eleventy-plugin-rss": "1.0.9",
         "@11ty/eleventy-plugin-syntaxhighlight": "3.0.1",
-        "@fluid-project/eleventy-plugin-fluid": "github:greatislander/eleventy-plugin-fluid#main"
+        "@fluid-project/eleventy-plugin-fluid": "github:fluid-project/eleventy-plugin-fluid#main"
     },
     "devDependencies": {
         "debug": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "@11ty/eleventy": "0.11.0",
         "@11ty/eleventy-plugin-rss": "1.0.9",
         "@11ty/eleventy-plugin-syntaxhighlight": "3.0.1",
-        "@fluid-project/eleventy-plugin-fluid": "github:fluid-project/eleventy-plugin-fluid#main"
+        "@fluid-project/eleventy-plugin-fluid": "github:fluid-project/eleventy-plugin-fluid#751e42299bde606b526ddc2183d18ad1557f6f58"
     },
     "devDependencies": {
         "debug": "4.2.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "dependencies": {
         "@11ty/eleventy": "0.11.0",
         "@11ty/eleventy-plugin-rss": "1.0.9",
-        "@11ty/eleventy-plugin-syntaxhighlight": "3.0.1"
+        "@11ty/eleventy-plugin-syntaxhighlight": "3.0.1",
+        "@fluid-project/eleventy-plugin-fluid": "github:greatislander/eleventy-plugin-fluid#main"
     },
     "devDependencies": {
         "debug": "4.2.0",
@@ -34,6 +35,7 @@
         "image-size": "0.9.1",
         "infusion": "3.0.0-dev.20200326T173810Z.24ddb2718",
         "jsdom": "16.4.0",
+        "rimraf": "^3.0.2",
         "slugify": "1.4.5"
     }
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "image-size": "0.9.1",
         "infusion": "3.0.0-dev.20200326T173810Z.24ddb2718",
         "jsdom": "16.4.0",
-        "rimraf": "^3.0.2",
+        "rimraf": "3.0.2",
         "slugify": "1.4.5"
     }
 }


### PR DESCRIPTION
Supersedes #25 and #26.

This is the first step towards moving all reusable configuration into an Eleventy plugin, which I'm working on over here for the time being: https://github.com/greatislander/eleventy-plugin-fluid